### PR TITLE
change karma-webpack-plugin dependency in generator common templates

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -33,7 +33,7 @@
     "karma-phantomjs-launcher": "~0.1.1",
     "karma": "~0.10.9",
     "grunt-karma": "~0.6.2",
-    "karma-webpack-plugin": "~1.0.0",
+    "karma-webpack": "~1.0.0",
     "webpack-dev-server": "~1.0.2",
     "jshint-loader": "~0.6.0",
     "coffee-script": "~1.7.1",


### PR DESCRIPTION
The package.json generated for new projects contained a dev dependency which doesn't exist, "karma-webpack-plugin". Should be "karma-webpack".
